### PR TITLE
Add support for multiple containers

### DIFF
--- a/src/main/resources/site/processors/google-tagmanager.js
+++ b/src/main/resources/site/processors/google-tagmanager.js
@@ -1,45 +1,52 @@
 var portal = require('/lib/xp/portal');
 
 exports.responseProcessor = function (req, res) {
+    if (req.mode !== 'live') return res; // Only add snippet if in live mode
 
-    var siteConfig =  portal.getSiteConfig();
-    var containerID = siteConfig['googleTagManagerContainerID'] || '';
+    var siteConfig = portal.getSiteConfig();
+    var containerIDs = [].concat(siteConfig['googleTagManagerContainerIDs'] || []);
+    var containerID = siteConfig['googleTagManagerContainerID'];
 
-    var headSnippet = '<!-- Google Tag Manager -->';
-    headSnippet += '<script>dataLayer = [];</script>';
-    headSnippet += '<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({\'gtm.start\':';
-    headSnippet += 'new Date().getTime(),event:\'gtm.js\'});var f=d.getElementsByTagName(s)[0],';
-    headSnippet += 'j=d.createElement(s),dl=l!=\'dataLayer\'?\'&l=\'+l:\'\';j.async=true;j.src=';
-    headSnippet += '\'//www.googletagmanager.com/gtm.js?id=\'+i+dl;f.parentNode.insertBefore(j,f);';
-    headSnippet += '})(window,document,\'script\',\'dataLayer\',\'' + containerID + '\');</script>';
-    headSnippet += '<!-- End Google Tag Manager -->';
-
-    var bodySnippet = '<!-- Google Tag Manager (noscript) -->';
-    bodySnippet += '<noscript><iframe name="Google Tag Manager" src="//www.googletagmanager.com/ns.html?id=' + containerID + '" ';
-    bodySnippet += 'height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>';
-    bodySnippet += '<!-- End Google Tag Manager (noscript) -->';
-
-    // Only add snippet if in live mode and containerID is set
-    if (req.mode === 'live' && containerID !== '') {
-
-        var headEnd = res.pageContributions.headEnd;
-        if (!headEnd) {
-            res.pageContributions.headEnd = [];
-        }
-        else if (typeof(headEnd) == 'string') {
-            res.pageContributions.headEnd = [headEnd];
-        }
-        res.pageContributions.headEnd.push(headSnippet);
-
-        var bodyBegin = res.pageContributions.bodyBegin;
-        if (!bodyBegin) {
-            res.pageContributions.bodyBegin = [];
-        }
-        else if (typeof(bodyBegin) == 'string') {
-            res.pageContributions.bodyBegin = [bodyBegin];
-        }
-        res.pageContributions.bodyBegin.push(bodySnippet);
+    if (containerID) {
+        containerIDs.push({ googleTagManagerContainerID: containerID });
     }
 
+    if (!containerIDs.length) return res;
+
+    var headEnd = res.pageContributions.headEnd;
+    var bodyBegin = res.pageContributions.bodyBegin;
+
+    if (!headEnd) {
+        res.pageContributions.headEnd = [];
+    }
+    else if (typeof (headEnd) == 'string') {
+        res.pageContributions.headEnd = [headEnd];
+    }
+
+    if (!bodyBegin) {
+        res.pageContributions.bodyBegin = [];
+    }
+    else if (typeof (bodyBegin) == 'string') {
+        res.pageContributions.bodyBegin = [bodyBegin];
+    }
+
+    for (var i = 0; i < containerIDs.length; i++) {
+        var headSnippet = '<!-- Google Tag Manager -->';
+        headSnippet += '<script>dataLayer = [];</script>';
+        headSnippet += '<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({\'gtm.start\':';
+        headSnippet += 'new Date().getTime(),event:\'gtm.js\'});var f=d.getElementsByTagName(s)[0],';
+        headSnippet += 'j=d.createElement(s),dl=l!=\'dataLayer\'?\'&l=\'+l:\'\';j.async=true;j.src=';
+        headSnippet += '\'//www.googletagmanager.com/gtm.js?id=\'+i+dl;f.parentNode.insertBefore(j,f);';
+        headSnippet += '})(window,document,\'script\',\'dataLayer\',\'' + containerIDs[i].googleTagManagerContainerID + '\');</script>';
+        headSnippet += '<!-- End Google Tag Manager -->';
+
+        var bodySnippet = '<!-- Google Tag Manager (noscript) -->';
+        bodySnippet += '<noscript><iframe name="Google Tag Manager" src="//www.googletagmanager.com/ns.html?id=' + containerIDs[i].googleTagManagerContainerID + '" ';
+        bodySnippet += 'height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>';
+        bodySnippet += '<!-- End Google Tag Manager (noscript) -->';
+
+        res.pageContributions.headEnd.push(headSnippet);
+        res.pageContributions.bodyBegin.push(bodySnippet);
+    }
     return res;
 };

--- a/src/main/resources/site/site.xml
+++ b/src/main/resources/site/site.xml
@@ -5,6 +5,16 @@
       <label>Container ID</label>
       <occurrences minimum="0" maximum="1"/>
     </input>
+    <item-set name="googleTagManagerContainerIDs">
+      <label>Extra container IDs</label>
+      <occurrences minimum="0" maximum="0"/>
+      <items>
+        <input name="googleTagManagerContainerID" type="TextLine">
+          <label>Container ID</label>
+          <occurrences minimum="1" maximum="1"/>
+        </input>
+      </items>
+    </item-set>
   </form>
   <processors>
     <response-processor name="google-tagmanager" order="10"/>


### PR DESCRIPTION
The reason for this pull request: When it comes to Conversion API (CAPI) one of our customer have two GTMs because one is used to host a server just for CAPI. It is not optimal to have two GTMs on the page, but this does not count as two GTMs. 