### PR TITLE
Bump version to 2.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ group = com.enonic.app
 projectName = google.tagmanager
 appName = com.enonic.app.google.tagmanager
 xpVersion=8.0.0-B4
-version=1.8.1-SNAPSHOT
+version=2.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary
- Bump master `version` from `1.8.1-SNAPSHOT` to `2.0.0-SNAPSHOT` now that the maintenance branch `1.x` has been forked off the post-`v1.8.0` SNAPSHOT commit (`0078ffd`) for the XP 7 line.
- Add `releaseBranch:` config to `.github/workflows/enonic-gradle.yml` listing both `master` and `1.x` so the `enonic/release-tools/build-and-publish` action treats both as release branches.

## Test plan
- [ ] CI green on this PR (`Gradle Build`)
- [ ] After merge: a push to `master` is recognized as a release branch
- [ ] After merge to `1.x` of the companion PR: a push to `1.x` is also recognized as a release branch

## Related
Companion PR on `1.x`: adds the same `releaseBranch:` block (no version bump) so pushes there are recognized — the action reads `releaseBranch:` from the branch's own workflow file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)