### PR TITLE
Add release-branch CI config for 1.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `releaseBranch:` block listing `master` and `1.x` to `.github/workflows/enonic-gradle.yml` on the `1.x` maintenance branch.
- Required because the `enonic/release-tools/build-and-publish` action reads `releaseBranch:` from the branch's own workflow file — pushes to `1.x` won't be recognized as release-branch builds without this edit landing on `1.x` itself.

No version bump and no other Step-2 (master) changes are copied here, by design — those are master-only.

## Test plan
- [ ] CI green on this PR (`Gradle Build`)
- [ ] After merge: a push to `1.x` is recognized as a release branch by `enonic/release-tools/build-and-publish`

## Related
Companion PR on `master` (#33): bumps `version` to `2.0.0-SNAPSHOT` and adds the same `releaseBranch:` block on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)